### PR TITLE
Tag v0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-banana-checker",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Checker for the 'Banana' JSON-file format for interface messages, as used by MediaWiki and jQuery.i18n.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixup release because the npm tarball for v0.7.0 was published
slightly before the git tag, and was missing an important fix
to the "bin" package.json setting.