### PR TITLE
More specific "lacks documentation in qqq.json" message

### DIFF
--- a/src/banana.js
+++ b/src/banana.js
@@ -183,11 +183,11 @@ module.exports = function bananaChecker( dir, options, logErr ) {
 			ok = false;
 
 			logErr(
-				count + ' message' + ( count > 1 ? 's lack' : ' lacks' ) + ' documentation.'
+				count + ' message' + ( count > 1 ? 's lack' : ' lacks' ) + ' documentation in qqq.json.'
 			);
 
 			sourceMessageMissing.forEach( function ( message ) {
-				logErr( 'Message "' + message + '" lacks documentation.' );
+				logErr( 'Message "' + message + '" lacks documentation in qqq.json.' );
 			} );
 		}
 	}

--- a/test/test.js
+++ b/test/test.js
@@ -129,8 +129,8 @@ console.log( 'test: requireCompleteMessageDocumentation' );
 	);
 	assert.strictEqual( result, FAIL );
 	assert.deepStrictEqual( errs, [
-		'1 message lacks documentation.',
-		'Message "third-message-key" lacks documentation.'
+		'1 message lacks documentation in qqq.json.',
+		'Message "third-message-key" lacks documentation in qqq.json.'
 	] );
 }
 


### PR DESCRIPTION
Especially for newbies it can be quite confusing to get an error message that talks about an unspecific "lack of documentation". I believe we can point the user directly to the file they need to edit.