### PR TITLE
Allow ignoring missing translations of blank source messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,3 +198,9 @@ Default value: `[]`
 Example value: `[ 'first-message-key', 'third-message-key' ]`
 
 Messages on which to fail if missing in any provided language.
+
+### ignoreMissingBlankTranslations
+Type: `boolean`
+Default value: `true`
+
+Whether to ignore missing translations whose original string is blank.

--- a/src/banana.js
+++ b/src/banana.js
@@ -23,6 +23,7 @@ module.exports = function bananaChecker( dir, options, logErr ) {
 		disallowDuplicateTranslations: false,
 		disallowUnusedDocumentation: true,
 		disallowUnusedTranslations: false,
+		ignoreMissingBlankTranslations: true,
 
 		requireCompleteMessageDocumentation: true,
 		requireCompleteTranslationLanguages: [],
@@ -122,6 +123,12 @@ module.exports = function bananaChecker( dir, options, logErr ) {
 			if ( languageMesages[ message ].trim() === '' ) {
 				blanks.push( message );
 			}
+		}
+
+		if ( options.ignoreMissingBlankTranslations ) {
+			missing = missing.filter( function ( message ) {
+				return sourceMessages[ message ] !== '';
+			} );
 		}
 
 		translatedData[ language ] = {

--- a/src/cli.js
+++ b/src/cli.js
@@ -25,6 +25,7 @@ for ( const param of params ) {
 		case 'disallowDuplicateTranslations':
 		case 'disallowUnusedDocumentation':
 		case 'disallowUnusedTranslations':
+		case 'ignoreMissingBlankTranslations':
 		case 'requireCompleteMessageDocumentation':
 		case 'requireLowerCase':
 		case 'requireMetadata':


### PR DESCRIPTION
For the requireCompleteTranslationLanguages and
requireCompleteTranslationMessages features, it doesn't make sense to
fail when a message whose source text is blank doesn't have a
translation. These messages aren't intended to be translated, and even
if they were translated as blanks, that would also fail because
disallowBlankTranslations is true by default.

This adds ignoreMissingBlankTranslations and sets it to true by default.
If enabled, a message is only considered missing if its source text is
non-empty. Blank source message do still require documentation.