### PR TITLE
Follow-up #77: Don't try to get original parameters for a message undefined in source

### DIFF
--- a/src/banana.js
+++ b/src/banana.js
@@ -110,9 +110,9 @@ module.exports = function bananaChecker( dir, options, logErr ) {
 		for ( index in keys ) {
 			message = keys[ index ];
 			if ( sourceMessages[ message ] === undefined ) {
-				// An unused translation. This happens on commits that remove messages, 
+				// An unused translation. This happens on commits that remove messages,
 				// which are typically removed from en.json and qqq.json, letting
-				// translations be removed by a localisation update instead. 
+				// translations be removed by a localisation update instead.
 				originalParameters = null;
 			} else {
 				originalParameters = sourceMessages[ message ].match( /\$\d/g );

--- a/src/banana.js
+++ b/src/banana.js
@@ -109,7 +109,11 @@ module.exports = function bananaChecker( dir, options, logErr ) {
 
 		for ( index in keys ) {
 			message = keys[ index ];
-			originalParameters = sourceMessages[ message ].match( /\$\d/g );
+			if ( sourceMessages[ message ] === undefined ) {
+				originalParameters = undefined;
+			} else {
+				originalParameters = sourceMessages[ message ].match( /\$\d/g );
+			}
 
 			if ( missing.indexOf( message ) !== -1 ) {
 				if ( languageMessages[ message ] === sourceMessages[ message ] ) {

--- a/src/banana.js
+++ b/src/banana.js
@@ -110,7 +110,10 @@ module.exports = function bananaChecker( dir, options, logErr ) {
 		for ( index in keys ) {
 			message = keys[ index ];
 			if ( sourceMessages[ message ] === undefined ) {
-				originalParameters = undefined;
+				// An unused translation. This happens on commits that remove messages, 
+				// which are typically removed from en.json and qqq.json, letting
+				// translations be removed by a localisation update instead. 
+				originalParameters = null;
 			} else {
 				originalParameters = sourceMessages[ message ].match( /\$\d/g );
 			}


### PR DESCRIPTION
It's probably missing deliberately.

This fixes the error in Gerrit I7462c09b.